### PR TITLE
Add directive for UA to deviler the value on manual navigation

### DIFF
--- a/draft-west-lang-client-hint.md
+++ b/draft-west-lang-client-hint.md
@@ -171,7 +171,8 @@ passive fingerprinting.
 Language preferences expose quite a bit of entropy to the web. User agents ought to exercise
 judgement before granting access to this information, and MAY impose restrictions above and beyond
 the secure transport and delegation requirements noted above. For instance, user agents could choose
-to deliver the `Sec-CH-Lang` header only on navigation, but not on subresource requests. Likewise,
+to deliver the `Sec-CH-Lang` header only on navigation, but not on subresource requests. User agents
+SHOULD deliver the `Sec-CH-Lang` header when the user enters the url manually. Likewise,
 they could offer users control over the values revealed to servers, or gate access on explicit user
 interaction via a permission prompt or via a settings interface.
 


### PR DESCRIPTION
The rationale behind this is to allow multilingual websites to be able to get the
prefered language early on, to be able to redirect the user to the proper page.
The main uses cases would be that the user typed the url for the homepage or
a short url that is language agnostic.

---

Re: https://mobile.twitter.com/nitriques/status/1096048204041338880

I've given it more thoughts, and I tried to propose a very wide change (my twitters suggested more to be done). I still think it can be improve, like navigation from another site. As I've said, the main concern here is for multilingual site to be able to "guess" the perfered language with user defined values, when allowed by the user.
